### PR TITLE
Add manufacturer specific projects

### DIFF
--- a/_data/projects/instrumentkit.yml
+++ b/_data/projects/instrumentkit.yml
@@ -11,7 +11,7 @@ has_procedures: false
 has_gui: false
 gui_technology: 
 has_unit_support: true
-unit_library: quantities (soon pint)
+unit_library: pint
 instrument_categories: yes
 remarks: 
 collected_by: "@bilderbuchi"

--- a/_data/projects/pico-python.yml
+++ b/_data/projects/pico-python.yml
@@ -1,0 +1,17 @@
+name: pico-python
+description: Python library for PicoTech Picoscope oscilloscopes
+repo_url: https://github.com/colinoflynn/pico-python
+docs_url: 
+license: MIT
+project_focus: Python wrapper for the Picoscope dll
+test_framework: 
+communication_types: DLL
+transport_layers: USB
+has_procedures: false
+has_gui: false
+gui_technology: 
+has_unit_support: false
+unit_library: 
+instrument_categories: no
+remarks: Requires the driver of the manufacturer, available for Windows, Mac, Linux
+collected_by: "@bmoneke"

--- a/_data/projects/pytrinamic.yml
+++ b/_data/projects/pytrinamic.yml
@@ -1,0 +1,17 @@
+name: PyTrinamic
+description: Python package for TRINAMIC motor cards
+repo_url: https://github.com/trinamic/PyTrinamic
+docs_url: 
+license: MIT
+project_focus: Python API for TINAMIC modules
+test_framework:
+communication_types: proprietary protocol
+transport_layers: USB, RS232, RS485, CAN, RTMI
+has_procedures: false
+has_gui: false
+gui_technology: 
+has_unit_support: false
+unit_library: 
+instrument_categories: yes
+remarks:
+collected_by: "@bmoneke"


### PR DESCRIPTION
I updated instrumentkit (which has transitioned to pint) and added two manufacturer specific projects. One is by the manufacturer itself and does not require drivers, the other one does require driver files.